### PR TITLE
encoding kwargs is not supported in python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
+import platform
 from setuptools import setup
 from os import path
 
 here = path.abspath(path.dirname(__file__))
+py_maj = int(platform.python_version().split('.')[0])
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+open_kwargs = {}
+if py_maj > 2:
+    open_kwargs = {'encoding': 'utf-8'}
+with open(path.join(here, 'README.md'), **open_kwargs) as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
Well, I don't know if it really useful to support python2 (it should be not supported on next month) but I have an issue to install your package on python2.7 due to a kwargs "enconding" when you open the `README.md`. It raise 
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/var/folders/2r/65tr5hbn2j595b7qlgsgd6mm0000gn/T/pip-install-VA7xuc/PyFortiAPI/setup.py", line 6, in <module>
        with open(path.join(here, 'README.md'), encoding='utf-8') as f:
TypeError: 'encoding' is an invalid keyword argument for this function```