### PR TITLE
fix bug regarding firewall address not found

### DIFF
--- a/pyfortiapi.py
+++ b/pyfortiapi.py
@@ -167,7 +167,7 @@ class FortiGate:
 
         :return: HTTP Status Code
         """
-        api_url = self.urlbase + "api/v2/cmdb/firewall/address/" + address
+        api_url = self.urlbase + "api/v2/cmdb/firewall/address/" + requests.utils.quote(address, safe='')
         # Check whether target object exists
         if not self.does_exist(api_url):
             logging.error('Requested address "{address}" does not exist in Firewall config.'.format(address=address))


### PR DESCRIPTION
Hi,

I'm getting an Error that the requested address does not exist when using `update_firewall_address`:

`ERROR:root:Requested address "010.005.018.121/32" does not exist in Firewall config.`

The problem is the name of the address, because the slash is not url-encoded: `https://192.168.1.99:1234/api/v2/cmdb/firewall/address/010.005.018.121/32`. The firewall interpret the address-name as `010.005.018.121`.

The url-encoded verison works: ``https://192.168.1.99:1234/api/v2/cmdb/firewall/address/010.005.018.121%2F32`.


Fix using requests: `requests.utils.quote(address, safe='')`

```python
def update_firewall_address(self, address, data):
        """
        Update firewall address record with provided data

        :param address: Address record being updated
        :param data: JSON Data with which to upate the address record

        :return: HTTP Status Code
        """
        api_url = self.urlbase + "api/v2/cmdb/firewall/address/" + requests.utils.quote(address, safe='')
        # Check whether target object exists
        if not self.does_exist(api_url):
            logging.error('Requested address "{address}" does not exist in Firewall config.'.format(address=address))
            return 404
        result = self.put(api_url, data)
        return result
```
